### PR TITLE
Update setup-package-list to skip newline

### DIFF
--- a/tools/setup-package-list
+++ b/tools/setup-package-list
@@ -27,7 +27,7 @@ def main(argv=None):
             package = [s.strip() for s in line.split()][:1]
             packages.append((package))
 
-    print(','.join(p[0] for p in packages))
+    print(','.join(p[0] for p in packages), end="")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The newline created by 'print' was breaking the use of this script