### PR TITLE
Make release_gap get packages if there are none present

### DIFF
--- a/release_gap.sh
+++ b/release_gap.sh
@@ -78,6 +78,12 @@ echo "::group::make"
 tools/subcyg "${ENV_BUILD_DIR}" "cd ${GAP_ROOT} && make -j2"
 echo "::endgroup::"
 
+# get GAP packages (if not already present)
+echo "::group::Get Packages"
+tools/subcyg "${ENV_BUILD_DIR}" "cd ${GAP_ROOT} && make bootstrap-pkg-full"
+tools/subcyg "${ENV_BUILD_DIR}" "cd ${GAP_ROOT} && rm -f packages.tar.gz"
+echo "::endgroup::"
+
 # build GAP packages
 echo "::group::Build Packages"
 tools/subcyg "${ENV_BUILD_DIR}" "cd ${GAP_ROOT}/pkg && (../bin/BuildPackages.sh --parallel || true)"


### PR DESCRIPTION
This makes the release_gap script get packages if there are none present. The main reason for this is to make the CI work again, as it clones GAP master but then fails as there are no packages to build. I've (hopefully) written it so it will work fine if there are no packages -- make bootstrap-pkg-full will do nothing, and the `rm -f` will also do nothing is there is no packages.tar.gz, but also won't fail.